### PR TITLE
Fix: brew version panics

### DIFF
--- a/brew/brew.go
+++ b/brew/brew.go
@@ -57,13 +57,13 @@ func (c *HomebrewClient) LatestTag(ctx context.Context) (*version.Version, error
 	out, err := pipeline.Output(
 		[]string{c.cmdPath, "info", c.getFullName()},
 		[]string{"head", "-1"},
-		[]string{"awk", "{ print $3 }"},
+		[]string{"awk", "{ print $4 }"},
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the latest info: %s", c.getFullName())
 	}
 
-	return version.Must(version.NewSemver(strings.TrimSpace(string(out)))), nil
+	return version.NewSemver(strings.TrimSpace(string(out)))
 }
 
 func (c *HomebrewClient) Update(ctx context.Context, _ *version.Version) error {

--- a/brew/brew.go
+++ b/brew/brew.go
@@ -57,7 +57,7 @@ func (c *HomebrewClient) LatestTag(ctx context.Context) (*version.Version, error
 	out, err := pipeline.Output(
 		[]string{c.cmdPath, "info", c.getFullName()},
 		[]string{"head", "-1"},
-		[]string{"grep", "-o", "-E", "([0-9]+\.){1}[0-9]+(\.[0-9]+)?"},
+		[]string{"grep", "-o", "-E", `([0-9]+\.){1}[0-9]+(\.[0-9]+)?`},
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the latest info: %s", c.getFullName())

--- a/brew/brew.go
+++ b/brew/brew.go
@@ -57,7 +57,7 @@ func (c *HomebrewClient) LatestTag(ctx context.Context) (*version.Version, error
 	out, err := pipeline.Output(
 		[]string{c.cmdPath, "info", c.getFullName()},
 		[]string{"head", "-1"},
-		[]string{"awk", "{ print $4 }"},
+		[]string{"grep", "-o", "-E", "([0-9]+\.){1}[0-9]+(\.[0-9]+)?"},
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the latest info: %s", c.getFullName())


### PR DESCRIPTION
Currently evans auto update logic panics due to changes in how brew print packages version info:
```
goroutine 20 [running]:
github.com/hashicorp/go-version.Must(...)
	/Users/ktr/.ghq/pkg/mod/github.com/hashicorp/go-version@v1.4.0/version.go:102
github.com/ktr0731/go-updater/brew.(*HomebrewClient).LatestTag(0x14000116090, {0x1039029e8, 0x1400043a880})
	/Users/ktr/.ghq/pkg/mod/github.com/ktr0731/go-updater@v0.1.5/brew/brew.go:66 +0x538
github.com/ktr0731/go-updater.(*Updater).Updatable(0x140001160c0, {0x1039029e8, 0x1400043a880})
	/Users/ktr/.ghq/pkg/mod/github.com/ktr0731/go-updater@v0.1.5/updater.go:48 +0x4c
github.com/ktr0731/evans/app.checkUpdate({0x1039029e8, 0x1400043a880}, 0x14000439050, 0x140002e7720)
	/Users/ktr/.ghq/src/github.com/ktr0731/evans/app/update.go:64 +0x1d0
github.com/ktr0731/evans/app.runREPLCommand.func1()
	/Users/ktr/.ghq/src/github.com/ktr0731/evans/app/commands.go:269 +0x44
golang.org/x/sync/errgroup.(*Group).Go.func1(0x14000443590, 0x140004435c0)
	/Users/ktr/.ghq/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x58
created by golang.org/x/sync/errgroup.(*Group).Go
	/Users/ktr/.ghq/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x60
```

This PR fixes the following

1. Removing `version.Must` to avoid panic and returning normal error

2. Extract correct package version from latest version of the brew
```sh
brew info ktr0731/evans/evans | head -1
==> ktr0731/evans/evans: stable 0.10.8
```